### PR TITLE
Make pokerfans scraper fetch interval configurable

### DIFF
--- a/bin/update_calendar.rb
+++ b/bin/update_calendar.rb
@@ -25,10 +25,15 @@ def process_date(date, api_key)
   pg_tournaments = pg_scraper.fetch_daily_tournaments
   pg_scraper.fetch_tournaments(pg_tournaments)
 
-  # pokerfans スクレイピングの実行（IPブロックのため一時停止）
-  # pf_scraper = PokerfansScraper.new(Settings::DATA_DIR, date)
-  # pf_events = pf_scraper.fetch_daily_tournaments
-  # pf_scraper.fetch_tournaments(pf_events)
+  # pokerfans スクレイピングの実行
+  # フェッチ間隔は Settings::POKERFANS_FETCH_INTERVAL で調整可能（IPブロック対策）
+  pf_scraper = PokerfansScraper.new(
+    Settings::DATA_DIR,
+    date,
+    fetch_interval: Settings::POKERFANS_FETCH_INTERVAL
+  )
+  pf_events = pf_scraper.fetch_daily_tournaments
+  pf_scraper.fetch_tournaments(pf_events)
 
   # AI解析の実行（該当日付の全 .txt ファイルを処理）
   analyzer = TournamentAnalyzer.new(api_key, Settings::DATA_DIR)

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -4,5 +4,9 @@ module PokerCalendar
     CONFIG_PATH = "config.json"
     DATA_DIR = "./data"
     DATA_RETENTION_DAYS = 7
+
+    # pokerfans スクレイピングで各フェッチの間隔（秒）。
+    # IPブロックを避けたい場合はこの値を大きくする。
+    POKERFANS_FETCH_INTERVAL = 2
   end
 end

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -7,6 +7,6 @@ module PokerCalendar
 
     # pokerfans スクレイピングで各フェッチの間隔（秒）。
     # IPブロックを避けたい場合はこの値を大きくする。
-    POKERFANS_FETCH_INTERVAL = 2
+    POKERFANS_FETCH_INTERVAL = 10
   end
 end

--- a/lib/poker_calendar/pokerfans_scraper.rb
+++ b/lib/poker_calendar/pokerfans_scraper.rb
@@ -11,10 +11,14 @@ module PokerCalendar
     # 素の curl UA だとボット判定されIPブロックされやすいため、ブラウザ相当のUAを付ける
     USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
 
-    def initialize(data_dir, date)
+    # デフォルトの各フェッチ間隔（秒）。呼び出し側で上書き可能。
+    DEFAULT_FETCH_INTERVAL = 2
+
+    def initialize(data_dir, date, fetch_interval: DEFAULT_FETCH_INTERVAL)
       @data_dir = data_dir
       @date = date
       @date_str = date.strftime("%Y/%m/%d")
+      @fetch_interval = fetch_interval
     end
 
     def fetch_daily_tournaments
@@ -34,7 +38,7 @@ module PokerCalendar
         break if events.size < 50  # 50件未満なら最後のページ
 
         page += 1
-        sleep(2)
+        sleep(@fetch_interval)
       end
 
       all_events.uniq { |e| e[:id] }
@@ -105,7 +109,7 @@ module PokerCalendar
         return
       end
 
-      sleep(2)
+      sleep(@fetch_interval)
       url = "#{BASE_URL}/events/#{event_id}"
       html = `curl -L --compressed -s -A "#{USER_AGENT}" -X GET "#{url}"`
 
@@ -150,7 +154,11 @@ if __FILE__ == $0
   require_relative '../../config/settings'
 
   date = ARGV[0] ? Time.parse(ARGV[0]) : Time.now
-  scraper = PokerCalendar::PokerfansScraper.new(PokerCalendar::Settings::DATA_DIR, date)
+  scraper = PokerCalendar::PokerfansScraper.new(
+    PokerCalendar::Settings::DATA_DIR,
+    date,
+    fetch_interval: PokerCalendar::Settings::POKERFANS_FETCH_INTERVAL
+  )
 
   puts "Fetching pokerfans events for #{date.strftime('%Y-%m-%d')}..."
   event_ids = scraper.fetch_daily_tournaments


### PR DESCRIPTION
## Summary

This PR makes the pokerfans scraper's fetch interval configurable to help prevent IP blocking. Previously, the scraper had a hardcoded 2-second delay between requests. Now it uses a configurable interval that defaults to 10 seconds and can be adjusted via settings.

## Key Changes

- **PokerfansScraper**: 
  - Added `DEFAULT_FETCH_INTERVAL` constant (2 seconds)
  - Modified `initialize` to accept optional `fetch_interval` parameter
  - Replaced hardcoded `sleep(2)` calls with `sleep(@fetch_interval)` in `fetch_daily_tournaments` and `fetch_event_info` methods
  - Updated script execution to pass fetch interval from settings

- **Settings**:
  - Added `POKERFANS_FETCH_INTERVAL = 10` configuration constant with documentation explaining it can be increased to avoid IP blocking

- **update_calendar.rb**:
  - Re-enabled pokerfans scraping (was previously commented out due to IP blocking concerns)
  - Updated to pass `fetch_interval` from settings when instantiating PokerfansScraper
  - Added clarifying comments about the configurable interval for IP block prevention

## Implementation Details

The fetch interval is now centrally managed through `Settings::POKERFANS_FETCH_INTERVAL`, making it easy to adjust the scraping behavior without modifying code. The default 10-second interval provides better protection against IP blocking compared to the previous 2-second hardcoded delay.

https://claude.ai/code/session_01RXspiHF6F6L2Yykf6Yr2EH