### PR TITLE
pokerfansを一覧ページのみのスクレイピングで再開

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ pokerguild.jp / pokerfans.jp
         │
         ▼
   TournamentScraper / PokerfansScraper   ... HTML取得 → data/*.txt
+                                             （pokerfans は robots.txt で /events/ が
+                                              Disallow のため一覧ページのみ取得し、
+                                              一覧に載る範囲の情報だけを保存する。
+                                              プライズ内訳は取得できない）
         │
         ▼
   TournamentAnalyzer                     ... OpenAI API (GPT-4o-mini) → data/res-*.json
@@ -115,6 +119,6 @@ pokerguild.jp / pokerfans.jp
 | パターン | 内容 |
 |---------|------|
 | `pg-YYYY-MM-DD-tourney-{id}.txt` | pokerguild.jp の HTML |
-| `pf-YYYY-MM-DD-event-{id}.txt` | pokerfans.jp の HTML |
+| `pf-YYYY-MM-DD-event-{id}.txt` | pokerfans.jp の一覧から整形したイベント情報 |
 | `res-{上記ファイル名}.json` | OpenAI API レスポンス |
 | `tourney_info_YYYY-MM-DD.csv` | 生成された CSV |

--- a/bin/update_calendar.rb
+++ b/bin/update_calendar.rb
@@ -25,16 +25,17 @@ def process_date(date, api_key)
   pg_tournaments = pg_scraper.fetch_daily_tournaments
   pg_scraper.fetch_tournaments(pg_tournaments)
 
-  # pokerfans スクレイピングは一時停止中（IPブロック対応）。
-  # 再開する場合は以下のコメントを外す。
-  # フェッチ間隔は Settings::POKERFANS_FETCH_INTERVAL で調整可能。
-  # pf_scraper = PokerfansScraper.new(
-  #   Settings::DATA_DIR,
-  #   date,
-  #   fetch_interval: Settings::POKERFANS_FETCH_INTERVAL
-  # )
-  # pf_events = pf_scraper.fetch_daily_tournaments
-  # pf_scraper.fetch_tournaments(pf_events)
+  # pokerfans スクレイピングの実行。
+  # robots.txt で /events/ が Disallow のため一覧ページのみ取得し、
+  # 一覧に載っている情報だけをイベント情報として保存する。
+  # 一覧の取得間隔は Settings::POKERFANS_FETCH_INTERVAL で調整可能。
+  pf_scraper = PokerfansScraper.new(
+    Settings::DATA_DIR,
+    date,
+    fetch_interval: Settings::POKERFANS_FETCH_INTERVAL
+  )
+  pf_events = pf_scraper.fetch_daily_tournaments
+  pf_scraper.save_tournaments(pf_events)
 
   # AI解析の実行（該当日付の全 .txt ファイルを処理）
   analyzer = TournamentAnalyzer.new(api_key, Settings::DATA_DIR)

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -5,8 +5,9 @@ module PokerCalendar
     DATA_DIR = "./data"
     DATA_RETENTION_DAYS = 7
 
-    # pokerfans スクレイピングで各フェッチの間隔（秒）。
-    # IPブロックを避けたい場合はこの値を大きくする。
+    # pokerfans の一覧ページを1ページ取得するごとに空ける間隔（秒）。
+    # robots.txt により個別イベントページは取得しないため、1日あたりの
+    # リクエストは一覧の数ページ分のみ。IPブロックを避けたい場合はこの値を大きくする。
     POKERFANS_FETCH_INTERVAL = 10
   end
 end

--- a/lib/poker_calendar/pokerfans_scraper.rb
+++ b/lib/poker_calendar/pokerfans_scraper.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+require 'cgi'
 require 'time'
 require_relative './loggable'
 
@@ -10,6 +11,13 @@ module PokerCalendar
     BASE_URL = 'https://pokerfans.jp'
     # 素の curl UA だとボット判定されIPブロックされやすいため、ブラウザ相当のUAを付ける
     USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+
+    # pokerfans の robots.txt は User-agent: * に対して /events/ を Disallow している。
+    # そのため個別イベントページは取得せず、許可されているトップページの一覧
+    # （クエリ付きの "/"）だけを取得し、一覧の1件分のHTMLブロックをそのまま
+    # イベント情報として保存する。取得できる項目は一覧に載っている範囲
+    # （タイトル・店名・住所・開始/締切時刻・参加費・定員）に限られ、
+    # 詳細ページにあったプライズ内訳は取得できない。
 
     # デフォルトの各フェッチ間隔（秒）。呼び出し側で上書き可能。
     DEFAULT_FETCH_INTERVAL = 2
@@ -28,7 +36,7 @@ module PokerCalendar
       while page <= 10
         log "Fetching pokerfans event list page #{page} for #{@date_str}"
         html_content = fetch_daily_page(page)
-        events = extract_event_ids(html_content)
+        events = extract_events(html_content)
 
         break if events.empty?
 
@@ -44,12 +52,11 @@ module PokerCalendar
       all_events.uniq { |e| e[:id] }
     end
 
-    def fetch_tournaments(events)
-      log "Fetching #{events.size} pokerfans events"
-      events.each_with_index do |event, index|
-        log "Fetching event #{index + 1}/#{events.size}: #{event[:id]}"
-        fetch_event_info(event)
-      end
+    # 一覧から抜き出したブロックを保存する。個別ページへのアクセスは行わないため
+    # ここでのHTTPリクエストは発生しない。
+    def save_tournaments(events)
+      log "Saving #{events.size} pokerfans events from the event list"
+      events.each { |event| save_event_info(event) }
     end
 
     def make_info_file_path(event_id)
@@ -70,24 +77,25 @@ module PokerCalendar
       html.force_encoding('UTF-8')
     end
 
-    def extract_event_ids(html_content)
-      # profile-event ブロックごとにイベントIDとタイトルを抽出
+    def extract_events(html_content)
+      # profile-event ブロックごとにイベントID・タイトル・ブロックHTMLを抽出
       events = []
       html_content.scan(/<div class="profile-event">(.*?)<\/div>\s*<\/div>\s*<\/div>/m).each do |match|
         block = match[0]
         id_match = block.match(/href="\/events\/(\d+)"/)
         title_match = block.match(/data-original-title="([^"]+)"/)
-        if id_match
-          events << {
-            id: id_match[1],
-            title: title_match ? title_match[1] : ''
-          }
-        end
+        next unless id_match
+
+        events << {
+          id: id_match[1],
+          title: title_match ? CGI.unescapeHTML(title_match[1]) : '',
+          html: block
+        }
       end
       events.uniq { |e| e[:id] }
     end
 
-    def fetch_event_info(event)
+    def save_event_info(event)
       event_id = event[:id]
       title = event[:title]
 
@@ -109,38 +117,75 @@ module PokerCalendar
         return
       end
 
-      sleep(@fetch_interval)
-      url = "#{BASE_URL}/events/#{event_id}"
-      html = `curl -L --compressed -s -A "#{USER_AGENT}" -X GET "#{url}"`
-
-      # エラーページの場合はスキップ
-      if html.include?('Error | Poker Fans')
-        log "SKIP: Error page returned for event #{event_id}"
-        return
-      end
-
-      # イベント情報部分のみ抽出して保存
-      event_section = extract_event_section(html)
-      File.write(file_path, event_section, encoding: 'UTF-8')
+      File.write(file_path, build_event_section(event), encoding: 'UTF-8')
     end
 
-    def extract_event_section(html)
-      html = html.force_encoding('UTF-8')
-      result = ""
+    # 一覧のブロックから項目を取り出し、ラベル付きテキストに整形する。
+    # 生のマークアップをそのままAIに渡すと定員やステータスラベル（Opening等）を
+    # 賞金・アドオン額と誤読するため、必要な項目だけを明示的に組み立てる。
+    def build_event_section(event)
+      block = event[:html]
+      start_time, deadline = extract_times(block)
 
-      # breadcrumbs からタイトルを抽出
-      title_match = html.match(/<div class="breadcrumbs">.*?<h1[^>]*>(.*?)<\/h1>/m)
-      if title_match
-        result += "<title>#{title_match[1]}</title>\n"
-      end
+      lines = ["タイトル: #{event[:title]}"]
+      lines << "開催日: #{@date_str}"
+      lines << "店舗: #{extract_venue(block)}"
+      lines << "開始時刻: #{start_time}" if start_time
+      lines << "レイトレジストレーション締切: #{deadline}" if deadline
+      lines << "参加費: #{extract_fee(block)}"
+      lines << "定員: #{extract_capacity(block)}"
+      lines << "プライズ: 一覧に記載なし（タイトルに保証額等の記載があればそれを使う）"
+      lines.join("\n") + "\n"
+    end
 
-      # job-description クラスがイベント詳細を含む
-      desc_match = html.match(/<div class="job-description">.*?<\/div>\s*<!--=== End Job Description ===/m)
-      if desc_match
-        result += desc_match[0]
-      end
+    def extract_venue(block)
+      match = block.match(/fa-home[^>]*><\/span>\s*<span>(.*?)<\/span>/m)
+      match ? CGI.unescapeHTML(match[1].strip) : ''
+    end
 
-      result.empty? ? html : result
+    # 一覧の日時表記は当日なら「今日(Tue) 21:00 (Deadline22:30)」、
+    # それ以外は「7月16日(Thu) 21:00 (Deadline22:30)」。
+    # 締切が開始時刻より前の場合は日をまたいでいるので翌日として扱う。
+    def extract_times(block)
+      match = block.match(/fa-clock-o[^>]*><\/i>\s*<strong[^>]*>(.*?)<\/strong>/m)
+      return [nil, nil] unless match
+
+      text = match[1]
+      start_match = text.match(/(\d{1,2}):(\d{2})/)
+      return [nil, nil] unless start_match
+
+      start_at = Time.new(@date.year, @date.month, @date.day, start_match[1].to_i, start_match[2].to_i)
+      deadline_match = text.match(/Deadline\s*(\d{1,2}):(\d{2})/)
+      return [format_time(start_at), nil] unless deadline_match
+
+      deadline_at = Time.new(@date.year, @date.month, @date.day, deadline_match[1].to_i, deadline_match[2].to_i)
+      deadline_at += 24 * 60 * 60 if deadline_at < start_at
+
+      [format_time(start_at), format_time(deadline_at)]
+    end
+
+    def format_time(time)
+      time.strftime("%Y/%m/%d %H:%M")
+    end
+
+    # 「3,100(E)」「1,500(R/A/E)」「Free」等。括弧内の記号は Entry/Rebuy/Add-on の
+    # 有無を示すだけで金額ではないため、金額部分だけを渡す。
+    def extract_fee(block)
+      match = block.match(/ion-social-yen-outline.*?<span>(.*?)<\/span>/m)
+      return '不明' unless match
+
+      fee = match[1].strip
+      return '0円（無料）' if fee =~ /free/i
+
+      amount = fee[/[\d,]+/]
+      amount ? "#{amount}円" : fee
+    end
+
+    def extract_capacity(block)
+      match = block.match(/icon-users.*?<span>\s*(\d+)\s*\/\s*<\/span>\s*<span>\s*(\d+)\s*<\/span>/m)
+      return '不明' unless match
+
+      "#{match[2]}人（現在のエントリー数 #{match[1]}人。これは定員であり賞金額ではない）"
     end
 
     def make_info_file_name(event_id)
@@ -161,9 +206,9 @@ if __FILE__ == $0
   )
 
   puts "Fetching pokerfans events for #{date.strftime('%Y-%m-%d')}..."
-  event_ids = scraper.fetch_daily_tournaments
-  puts "Found #{event_ids.size} events"
+  events = scraper.fetch_daily_tournaments
+  puts "Found #{events.size} events"
 
-  scraper.fetch_tournaments(event_ids)
+  scraper.save_tournaments(events)
   puts "Done."
 end


### PR DESCRIPTION
## 概要

pokerfans の robots.txt は `User-agent: *` に対して `/events/` を Disallow しているため、個別イベントページの取得を廃止し、許可されている一覧ページ（クエリ付きの `/`）だけから情報を取得する方式に作り替えて再開する。

## 変更点

- 一覧の1件分のブロックから項目を抽出し、これまでと同じ `pf-{日付}-event-{id}.txt` に保存する。ファイル名・保存場所を変えていないため、下流の解析・CSV化・アップロードは無改修で動作する
- 生のマークアップをそのまま AI に渡すと、定員の「40」を `add_on`、ステータスラベル「Opening」を `prize_text` と誤読したため、タイトル・店舗・住所・開始時刻・締切・参加費・定員をラベル付きテキストに整形してから渡す
- 一覧の日時表記が当日だけ「今日(Tue)」、他日は「7月16日(Thu)」と変わるため正規化し、締切が開始より前の場合は日跨ぎとして翌日に補正する（23:00開始 → 翌01:00締切）
- リクエスト数がイベントごとの数百件から一覧の数ページ分に減るため、停止の原因だった IP ブロックのリスクも下がる

## 割り切った点

一覧に賞金の記載がないため、プライズ内訳は取得できず `prize_list` は基本的に空になる（プライズ情報はタイトル文言から読める分のみ）。ただし同一イベントが pokerguild にもある場合は重複排除で情報量の多い pokerguild 側が残るため、pokerfans 行が残るのは pokerguild に無いイベントのみ。

## 動作確認

7/16 の一覧を実際に取得し、216件中32件（既存のリング除外・コイン系キーワードのフィルタ通過分）を保存。うち2件を解析に投げ、誤読が解消し店名・住所・エリア・開始/締切時刻・参加費が正しく取れることを確認した。タイトルに保証額があれば `guaranteed_amount` / `is_coin_prize` も拾える。

なお、この検証は OpenAI 経由で実施しており、**ローカルLLM(LM Studio)での検証は未実施**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)