### PR TITLE
Vercel BlobへのJSONアップロード機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ config.json
 test.log
 .bundle/
 vendor/
+.vercel_blob_token

--- a/README.md
+++ b/README.md
@@ -77,8 +77,27 @@ pokerguild.jp / pokerfans.jp
   TournamentParser                       ... JSON → CSV (data/tourney_info_*.csv)
         │
         ▼
-  GoogleSpreadsheetUploader              ... CSV → Google Spreadsheet
+  GoogleSpreadsheetUploader              ... CSV → Google Spreadsheet（データ確認用）
+        │
+        ▼
+  VercelBlobUploader                     ... CSV → JSON → Vercel Blob（フロントエンドの読み込み元）
 ```
+
+### Vercel Blob へのアップロード
+
+フロントエンド（poker-calender-front）の読み込み高速化のため、CSV と同内容の JSON を
+Vercel Blob（`tournaments.json`）にアップロードする。スプレッドシートへのアップロードは
+データ確認用として並行して継続する。
+
+セットアップ:
+
+1. Vercel ダッシュボード → Storage → Blob でストアを作成
+2. Read/Write トークンを発行し、以下のいずれかで設定
+   - 環境変数 `BLOB_READ_WRITE_TOKEN`
+   - リポジトリ直下に `.vercel_blob_token` ファイルを置く（gitignore 済み）
+
+トークン未設定の場合は Blob アップロードをスキップし、従来どおりスプレッドシートのみ更新する。
+初回アップロード後にログに出力される Blob URL を、フロントエンドの `app.js` の `JSON_URL` に設定する。
 
 ### 主要ファイル
 
@@ -90,6 +109,7 @@ pokerguild.jp / pokerfans.jp
 | [lib/poker_calendar/tournament_analyzer.rb](lib/poker_calendar/tournament_analyzer.rb) | OpenAI API による構造化データ抽出 |
 | [lib/poker_calendar/tournament_parser.rb](lib/poker_calendar/tournament_parser.rb) | JSON → CSV 変換 |
 | [lib/poker_calendar/google_spreadsheet_uploader.rb](lib/poker_calendar/google_spreadsheet_uploader.rb) | Google Spreadsheet アップロード |
+| [lib/poker_calendar/vercel_blob_uploader.rb](lib/poker_calendar/vercel_blob_uploader.rb) | Vercel Blob へ JSON アップロード |
 | [config/settings.rb](config/settings.rb) | 定数定義 |
 
 ### 抽出フィールド

--- a/bin/update_calendar.rb
+++ b/bin/update_calendar.rb
@@ -3,6 +3,7 @@ require_relative '../lib/poker_calendar/pokerfans_scraper'
 require_relative '../lib/poker_calendar/tournament_analyzer'
 require_relative '../lib/poker_calendar/tournament_parser'
 require_relative '../lib/poker_calendar/google_spreadsheet_uploader'
+require_relative '../lib/poker_calendar/vercel_blob_uploader'
 require_relative '../lib/poker_calendar/data_cleaner'
 require_relative '../config/settings'
 
@@ -57,6 +58,27 @@ def analysis_coverage_ok?(date)
   res.to_f / txt >= COVERAGE_THRESHOLD
 end
 
+def vercel_blob_token
+  token = ENV["BLOB_READ_WRITE_TOKEN"].to_s.strip
+  return token unless token.empty?
+  return File.read(Settings::VERCEL_BLOB_TOKEN_PATH).strip if File.exist?(Settings::VERCEL_BLOB_TOKEN_PATH)
+
+  nil
+end
+
+def upload_to_vercel_blob(csv_files)
+  token = vercel_blob_token
+  if token.nil? || token.empty?
+    # 未設定でもスプレッドシート運用は継続できるよう、エラーにせずスキップする
+    puts "Vercel Blobトークンが未設定のためスキップします" \
+         "（環境変数 BLOB_READ_WRITE_TOKEN か #{Settings::VERCEL_BLOB_TOKEN_PATH} で設定）"
+    return
+  end
+
+  blob_uploader = VercelBlobUploader.new(token)
+  blob_uploader.upload_csv_as_json(csv_files, Settings::VERCEL_BLOB_PATHNAME)
+end
+
 def main
   # --csv-only: スクレイピング・AI解析を行わず、既存JSONからCSV生成とアップロードのみ実行
   csv_only = ARGV.include?('--csv-only')
@@ -97,8 +119,12 @@ def main
   end
 
   # Google Spreadsheetへのアップロード（複数CSVファイル）
+  # データ確認用としてBlob移行後も残す
   uploader = GoogleSpreadsheetUploader.new(Settings::CONFIG_PATH)
   uploader.upload_csv(csv_files, Settings::SPREADSHEET_KEY)
+
+  # Vercel Blobへのアップロード（フロントエンドの読み込み元）
+  upload_to_vercel_blob(csv_files)
 
   # 古いデータのクリーンアップ（csv-only時はスキップ）
   unless csv_only

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -2,6 +2,11 @@ module PokerCalendar
   module Settings
     SPREADSHEET_KEY = "17qhppvCNRnIX2wagimoAl6YHmaTaC0Re3ndwToletc0"
     CONFIG_PATH = "config.json"
+
+    # Vercel Blob 連携。トークンは環境変数 BLOB_READ_WRITE_TOKEN か、
+    # このファイルパスに置いたトークン文字列のどちらかで渡す（ファイルはgitignore済み）
+    VERCEL_BLOB_TOKEN_PATH = ".vercel_blob_token"
+    VERCEL_BLOB_PATHNAME = "tournaments.json"
     DATA_DIR = "./data"
     DATA_RETENTION_DAYS = 7
 

--- a/lib/poker_calendar/vercel_blob_uploader.rb
+++ b/lib/poker_calendar/vercel_blob_uploader.rb
@@ -1,0 +1,74 @@
+require 'net/http'
+require 'uri'
+require 'json'
+require 'csv'
+require 'time'
+require_relative './loggable'
+
+module PokerCalendar
+  # 生成済みCSVをJSONに変換して Vercel Blob にアップロードする。
+  # フロントエンドは Google Spreadsheet の公開CSVの代わりにこのJSONを読む。
+  # スプレッドシートへのアップロードはデータ確認用として並行して残す。
+  class VercelBlobUploader
+    include Loggable
+
+    API_ORIGIN = "https://blob.vercel-storage.com"
+    # CDNキャッシュ秒数。データ更新は1日2回だが、更新後に反映が遅れすぎないよう5分にする
+    CACHE_MAX_AGE = 300
+
+    def initialize(token)
+      @token = token
+    end
+
+    # csv_files を結合してJSON化し、pathname (例: "tournaments.json") へ上書きアップロードする
+    def upload_csv_as_json(csv_files, pathname)
+      tournaments = load_tournaments(Array(csv_files))
+      if tournaments.empty?
+        raise "アップロード対象のデータ行が0件のため、Vercel Blobへのアップロードを中止しました。"
+      end
+
+      payload = JSON.generate({
+        updated_at: Time.now.iso8601,
+        count: tournaments.size,
+        tournaments: tournaments,
+      })
+
+      url = put_blob(pathname, payload)
+      log "Uploaded #{tournaments.size} tournaments to Vercel Blob: #{url}"
+      url
+    end
+
+    private
+
+    def load_tournaments(csv_files)
+      csv_files.select { |f| File.exist?(f) }.flat_map do |file|
+        CSV.read(file, encoding: 'UTF-8', headers: true).map do |row|
+          # PapaParse(フロントエンド)は空セルを "" で返すため、nil を "" に揃える
+          row.to_h.transform_values { |v| v.nil? ? "" : v }
+        end
+      end
+    end
+
+    def put_blob(pathname, body)
+      uri = URI("#{API_ORIGIN}/#{pathname}")
+      req = Net::HTTP::Put.new(uri)
+      req['Authorization'] = "Bearer #{@token}"
+      req['x-api-version'] = '11'
+      req['x-content-type'] = 'application/json'
+      req['x-add-random-suffix'] = '0'   # 固定URLで配信するためサフィックスなし
+      req['x-allow-overwrite'] = '1'     # 毎回同じパスに上書き
+      req['x-cache-control-max-age'] = CACHE_MAX_AGE.to_s
+      req.body = body
+
+      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, read_timeout: 60) do |http|
+        http.request(req)
+      end
+
+      unless res.is_a?(Net::HTTPSuccess)
+        raise "Vercel Blobへのアップロードに失敗しました: HTTP #{res.code} #{res.body}"
+      end
+
+      JSON.parse(res.body)["url"]
+    end
+  end
+end


### PR DESCRIPTION
## 変更内容

- `lib/poker_calendar/vercel_blob_uploader.rb` を新規追加: 生成済みCSV（昨日・今日・明日分）を結合してJSON化し、Vercel Blob の `tournaments.json` へ固定URLで上書きアップロードする（標準ライブラリのみ、gem追加なし。CDNキャッシュ5分）
- `bin/update_calendar.rb`: スプレッドシートアップロードの直後にBlobアップロードを追加。**スプレッドシートへのアップロードはデータ確認用として継続**
- `config/settings.rb`: Blob関連の定数（トークンファイルパス・アップロード先パス名）を追加
- `.gitignore`: `.vercel_blob_token` を追加
- `README.md`: セットアップ手順とアーキテクチャ図を更新

## 背景

フロントエンド（poker-calendar-front [#18](https://github.com/okihara/poker-calendar-front/pull/18)）がスプレッドシート公開CSVを直接取得しており応答が遅いため、データ発生源であるこのスクレイパーからCDN配信のJSONを直接アップロードする構成に変更する。

## レビュー時の注意点

- トークン未設定の間はBlobアップロードを警告表示のみでスキップするため、**マージしても既存のcron運用は壊れない**
- スプレッドシート側と同様に、データ行0件の場合はアップロードを中止する（空データ上書き事故防止）
- Rubyの`CSV`は空セルを`nil`で返すため`""`に正規化し、フロントのPapaParse出力と互換にしている
- 実データCSV 404件でJSON変換をドライラン済み。フロント側でもそのJSONを読ませて表示確認済み

## セットアップ（マージ後）

1. Vercelダッシュボード → Storage → Blob でストアを作成し、Read/Writeトークンを発行
2. リポジトリ直下に `.vercel_blob_token` としてトークンを保存（または環境変数 `BLOB_READ_WRITE_TOKEN`）
3. `ruby bin/update_calendar.rb --csv-only` を実行し、ログに出るBlob URLをフロントの `JSON_URL` に設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)